### PR TITLE
refactor: Use args as dict instead of struct

### DIFF
--- a/src/package_io/input.star
+++ b/src/package_io/input.star
@@ -4,7 +4,7 @@ def parse_input(input_args):
 	default_args = struct(
 		backend_ip_address = DEFAULT_BACKEND_IP_ADDRESS
 	)
-	if not "backend_ip_address" in input_args:
+	if "backend_ip_address" not in input_args:
 		return default_args
 
 	if type(input_args["backend_ip_address"]) != "string":

--- a/src/package_io/input.star
+++ b/src/package_io/input.star
@@ -4,13 +4,13 @@ def parse_input(input_args):
 	default_args = struct(
 		backend_ip_address = DEFAULT_BACKEND_IP_ADDRESS
 	)
-	if not hasattr(input_args, "backend_ip_address"):
+	if not "backend_ip_address" in input_args:
 		return default_args
 
-	if type(input_args.backend_ip_address) != "string":
+	if type(input_args["backend_ip_address"]) != "string":
 		fail("backend_ip_address has to be of type string got {0}".format(type(input_args.backend_ip_address)))
 
-	if input_args.backend_ip_address.strip() == "":
+	if input_args["backend_ip_address"].strip() == "":
 		fail("backend_ip_address cannot be empty")
 
-	return input_args
+	return struct(backend_ip_address = input_args["backend_ip_address"])


### PR DESCRIPTION
Changelog picked up from commits here:

refactor: Use args as dict instead of struct